### PR TITLE
Error styling, Splash Page update

### DIFF
--- a/frontend/src/components/modal/session_form/login_form.jsx
+++ b/frontend/src/components/modal/session_form/login_form.jsx
@@ -51,6 +51,9 @@ class LoginForm extends React.Component {
             {/* <div onClick={this.props.closeModal} className="login-close-x">
               ✕
             </div> */}
+
+            <div className="login-form-errors">{this.showErrors()}</div>
+
             <label>
               <input
                 type="text"
@@ -86,7 +89,7 @@ class LoginForm extends React.Component {
                 {this.props.otherForm}
               </label>
             </div>
-          <div className="login-form-errors">{this.showErrors()}</div>
+          
           </form>
         </div>
       );

--- a/frontend/src/components/modal/session_form/signup_form.jsx
+++ b/frontend/src/components/modal/session_form/signup_form.jsx
@@ -48,7 +48,8 @@ class SignupForm extends React.Component {
             {/* <div onClick={this.props.closeModal} className="login-close-x">
               ✕
             </div> */}
-
+            <div className="signup-form-errors">{this.showErrors()}</div>
+            
             <label>
               <input
                 type="text"
@@ -106,7 +107,7 @@ class SignupForm extends React.Component {
                 {/* Link to other switch to signup form */}
               </label>
             </div>
-            <div className="signup-form-errors">{this.showErrors()}</div>
+            
           </form>
         </div>
       );

--- a/frontend/src/components/search/attraction_show_page.js
+++ b/frontend/src/components/search/attraction_show_page.js
@@ -1,7 +1,7 @@
 import React from 'react';
 // import { Link } from 'react-router-dom';
 import { withRouter } from 'react-router-dom';
-// import TravelMap from '../map/map';
+import TravelMap from '../map/map';
 // import AttractionsBox from '../attractions_index/AttractionsBox';
 // import SearchBar from './search';
 

--- a/frontend/src/styles/components/login_form.scss
+++ b/frontend/src/styles/components/login_form.scss
@@ -6,7 +6,7 @@
     justify-content: left;
     border-radius: 10px;
     width: 500px;
-    height: 250px;
+    // height: 250px;
     padding: 20px;
     display: flex;
     justify-content: center;
@@ -57,6 +57,13 @@
 }
 
 .login-form-errors {
-    background: white;
+    background: transparent;
     width: 200px;
+    color: floralwhite;
+}
+
+.login-form-errors ul li {
+    color: floralwhite;
+    margin-left: 10px;
+    font-family: "Pacifico", cursive;
 }

--- a/frontend/src/styles/components/signup_form.scss
+++ b/frontend/src/styles/components/signup_form.scss
@@ -9,7 +9,7 @@
     justify-content: left;
     border-radius: 10px;
     width: 500px;
-    height: 400px;
+    // height: 400px;
     padding: 20px;
     display: flex;
     justify-content: center;
@@ -54,6 +54,12 @@
 }
 
 .signup-form-errors {
-    background: white;
+    background: transparent;
     width: 200px;
+}
+
+.signup-form-errors ul li {
+    color: floralwhite;
+    margin-left: 10px;
+    font-family: "Pacifico", cursive;
 }

--- a/frontend/src/styles/components/video_player.scss
+++ b/frontend/src/styles/components/video_player.scss
@@ -1,7 +1,7 @@
 .video-container {
   top: 0;
   background-repeat: no-repeat;
-  background-size: contain;
+  background-size: cover;
   height: 100vh;
   width: 100vw;
   background-image: url(https://i.imgur.com/fkw84Dd.gif);


### PR DESCRIPTION
- white space on splash was removed by switching background: contain; to background: cover;

- errors rendering involved commenting out the height for the containers so when the errors render they do not push outside of the element and hangout

- the errors now render below the modal title above the first input box and changes the size of the modal container natrually